### PR TITLE
Use clang because xlclang has a runtime issue

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -5,6 +5,7 @@ export ZOPEN_TYPE="TARBALL"
 export ZOPEN_TARBALL_URL="https://tukaani.org/xz/xz-5.2.5.tar.gz"
 export ZOPEN_TARBALL_DEPS="curl gzip make zoslib"
 export ZOPEN_BOOTSTRAP=skip
+export ZOPEN_COMP=CLANG
 
 export ZOPEN_GIT_URL="https://git.tukaani.org/xz.git"
 export ZOPEN_GIT_DEPS="git make"


### PR DESCRIPTION
* To resolve the runtime issue on zopen check