### PR TITLE
Fix xzport broken build

### DIFF
--- a/patches/configure.patch
+++ b/patches/configure.patch
@@ -1,0 +1,15 @@
+diff --git a/configure b/configure
+index f103a6b..d7ac810 100755
+--- a/configure
++++ b/configure
+@@ -8561,6 +8561,10 @@ aix[4-9]*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
+ 
++openedition)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
++
+ beos*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;


### PR DESCRIPTION
Specify lt_cv_deplibs_check_method=pass_all to be able to pass .o files during link step